### PR TITLE
No hamburger, "menu"

### DIFF
--- a/pages/static/css/app.scss
+++ b/pages/static/css/app.scss
@@ -96,10 +96,20 @@ hr {border-color: $light-gray;}
   a {color: $white; margin-right: 8px; font-size: 17px;}
 }
 
-.title-bar { // for "small" screens
-	background: $primary;
-	a, a:hover {color: $yellow-dark;}
+.title-bar {
+  background: $primary;
+  align-items: center;
+  justify-content: space-between;
+  padding: 5px 5px 5px 10px;
+
+  a, a:hover {color: $yellow-light;}
+
+  .menu-button {
+    margin-bottom: 0;
+    align-self: flex-end;
+  }
 }
+
 .top-bar {
     @include breakpoint(medium) {
         background: $primary;

--- a/utils/templates/utils/tags/navigation/top_menu.html
+++ b/utils/templates/utils/tags/navigation/top_menu.html
@@ -6,8 +6,8 @@
 <div data-sticky data-options="marginTop:0;" style="width:100%;z-index:10000;">
 
     <div class="title-bar" data-responsive-toggle="menu" data-hide-for="large">
-        <button class="menu-icon" type="button" style="background: transparent;"data-toggle></button>
         <div class="title-bar-title"><a href="{% pageurl site_root %}">Grand Rapids Historical Society</a></div>
+        <button class="button blue menu-button" data-toggle>Menu</button>
     </div>
 
     <div class="top-bar" id="menu">


### PR DESCRIPTION
Client requested, very sensibly, something clearer than the hamburgemenu. Brittaney proposed this: 

![](https://files.slack.com/files-pri/T02UCPG5P-FDUG7GEUQ/screen_shot_2018-11-03_at_9.20.14_pm.png)

This PR is imperfect, but a push in that direction.