### PR TITLE
Remove Testimonial and FAQ models

### DIFF
--- a/pages/models.py
+++ b/pages/models.py
@@ -294,31 +294,6 @@ VideoGalleryPage.promote_panels = Page.promote_panels + [
 ]
 
 
-class TestimonialPage(Page):
-    intro = RichTextField(blank=True)
-    feed_image = models.ForeignKey(
-        Image,
-        null=True,
-        blank=True,
-        on_delete=models.SET_NULL,
-        related_name='+'
-    )
-
-    search_fields = Page.search_fields + [
-        index.SearchField('intro'),
-    ]
-
-
-TestimonialPage.content_panels = [
-    FieldPanel('title', classname="full title"),
-    FieldPanel('intro', classname="full"),
-]
-
-TestimonialPage.promote_panels = Page.promote_panels + [
-    ImageChooserPanel('feed_image'),
-]
-
-
 class ContentBlock(LinkFields):
     page = models.ForeignKey(
         Page,
@@ -344,34 +319,6 @@ class ContentBlock(LinkFields):
         return u"{0}[{1}]".format(self.title, self.slug)
 
 register_snippet(ContentBlock)
-
-
-class Testimonial(LinkFields):
-    page = models.ForeignKey(
-        Page,
-        related_name='testimonials',
-        null=True,
-        blank=True,
-        on_delete=models.SET_NULL
-    )
-    name = models.CharField(max_length=150)
-    photo = models.ForeignKey(
-        Image, null=True, blank=True, on_delete=models.SET_NULL
-    )
-    text = RichTextField(blank=True)
-
-    panels = [
-        PageChooserPanel('page'),
-        FieldPanel('name'),
-        ImageChooserPanel('photo'),
-        FieldPanel('text'),
-        MultiFieldPanel(LinkFields.panels, "Link"),
-    ]
-
-    def __str__(self):
-        return self.name
-
-register_snippet(Testimonial)
 
 
 class Advert(LinkFields):
@@ -402,17 +349,3 @@ class Advert(LinkFields):
         return self.title
 
 register_snippet(Advert)
-
-
-# Faqs Page
-
-class FaqsPage(Page):
-    body = StreamField([
-        ('faq_question', blocks.CharBlock(classname="full title")),
-        ('faq_answer', blocks.RichTextBlock()),
-    ])
-
-FaqsPage.content_panels = [
-    FieldPanel('title', classname="full title"),
-    StreamFieldPanel('body'),
-]

--- a/utils/templatetags/grhs_site_utils.py
+++ b/utils/templatetags/grhs_site_utils.py
@@ -6,7 +6,7 @@ from wagtail.documents.models import Document
 from contact.models import ContactPage
 from blog.models import BlogPage
 from events.models import EventPage
-from pages.models import Testimonial, Advert
+from pages.models import Advert
 
 register = template.Library()
 


### PR DESCRIPTION
I tried to also remove/comment-out the `documents_gallery` and `people` apps (and thus their models).  But there are default pages of those types, and you wouldnt' be able to delete them then.  And I couldn't easily remove them from the initial_data.sql either.  So we're left with them as types.